### PR TITLE
0xbinder patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ adb shell
 ```
 ```bash
 su
+```
+```bash
 mount -o rw,remount /
 ```
 ```bash


### PR DESCRIPTION
separate su and mount commands for easy copying. When you copy them as a single command it causes an error 